### PR TITLE
Fix: Enable diarization model selection for in-app recordings

### DIFF
--- a/src/upload.html
+++ b/src/upload.html
@@ -436,7 +436,8 @@
                 // Display recording info
                 recordingSize.textContent = formatFileSize(audioBlob.size);
                 recordingInfo.style.display = 'block';
-                speakerSection.style.display = 'block';
+                modelSelection.style.display = 'flex';
+                updateModelDisplay();
                 transcribeBtn.style.display = 'block';
 
                 // Reset UI


### PR DESCRIPTION
Fixes #15

Previously, the model selection UI was only shown for file uploads, preventing users from choosing speaker identification (diarization) when recording audio directly in the app. Now the model selection is displayed for both upload and recording modes.

### Changes
- Modified `src/upload.html` to display model selection UI after recording stops
- Added `modelSelection.style.display = 'flex'` and `updateModelDisplay()` to recording stop handler

Generated with [Claude Code](https://claude.ai/code)